### PR TITLE
[Rosa] 로그인 화면의 키보드 UI 수정

### DIFF
--- a/Krello.xcodeproj/project.pbxproj
+++ b/Krello.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		2489037CC5378EEE0CE8730A /* Pods_Krello.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D15D9EBA901D0B5B1CA0FD61 /* Pods_Krello.framework */; };
+		6FD292C12824E7A000A0ED7E /* LoginViewTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD292C02824E79F00A0ED7E /* LoginViewTest.swift */; };
+		6FD292C22824E98B00A0ED7E /* Preview.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC0B745C28225BDD007AE2B6 /* Preview.swift */; };
 		9CFD1B2C1F608EA9228C54AB /* Pods_KrelloTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 992A62047D85C6E5349BC267 /* Pods_KrelloTests.framework */; };
 		BC0B745D28225BDD007AE2B6 /* Preview.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC0B745C28225BDD007AE2B6 /* Preview.swift */; };
 		BC0B746528236A35007AE2B6 /* KrelloTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCC51E0F28210F5800CDD04F /* KrelloTests.swift */; };
@@ -45,6 +47,7 @@
 
 /* Begin PBXFileReference section */
 		01560B6CE738BCBD939EADB8 /* Pods-Krello.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Krello.release.xcconfig"; path = "Target Support Files/Pods-Krello/Pods-Krello.release.xcconfig"; sourceTree = "<group>"; };
+		6FD292C02824E79F00A0ED7E /* LoginViewTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewTest.swift; sourceTree = "<group>"; };
 		8302E3DED610EF1C02403E3E /* Pods-KrelloTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KrelloTests.debug.xcconfig"; path = "Target Support Files/Pods-KrelloTests/Pods-KrelloTests.debug.xcconfig"; sourceTree = "<group>"; };
 		992A62047D85C6E5349BC267 /* Pods_KrelloTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_KrelloTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A3D344D63B79E92BEEC611E7 /* Pods-KrelloTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KrelloTests.release.xcconfig"; path = "Target Support Files/Pods-KrelloTests/Pods-KrelloTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -147,6 +150,7 @@
 			isa = PBXGroup;
 			children = (
 				BCC51E0F28210F5800CDD04F /* KrelloTests.swift */,
+				6FD292C02824E79F00A0ED7E /* LoginViewTest.swift */,
 			);
 			path = KrelloTests;
 			sourceTree = "<group>";
@@ -447,10 +451,12 @@
 			files = (
 				BC22098228239D7000159AC0 /* LoginViewController.swift in Sources */,
 				BC0B746528236A35007AE2B6 /* KrelloTests.swift in Sources */,
+				6FD292C12824E7A000A0ED7E /* LoginViewTest.swift in Sources */,
 				BC2209882823A87700159AC0 /* LoginView.swift in Sources */,
 				BC2209912823AE1600159AC0 /* LayoutAnchor+Extension.swift in Sources */,
 				BC2209852823A86000159AC0 /* DefaultView.swift in Sources */,
 				BC22098B2823AD9900159AC0 /* UIColor+Extension.swift in Sources */,
+				6FD292C22824E98B00A0ED7E /* Preview.swift in Sources */,
 				BC22098E2823ADB200159AC0 /* UIStackView+Extension.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Krello/Controller/LoginView.swift
+++ b/Krello/Controller/LoginView.swift
@@ -186,7 +186,11 @@ class LoginView: DefaultView {
 // MARK: - UITextFieldDelegate
 extension LoginView: UITextFieldDelegate {
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-        textField.resignFirstResponder()
+        if textField == emailTextField {
+            passwordTextField.becomeFirstResponder()
+        } else {
+            passwordTextField.resignFirstResponder()
+        }
         return true
     }
 }

--- a/Krello/Controller/LoginView.swift
+++ b/Krello/Controller/LoginView.swift
@@ -42,9 +42,39 @@ class LoginView: DefaultView {
     override init(frame: CGRect) {
         super.init(frame: frame)
         createdSubviews()
+        setupKeyboardActions()
+
+        self.emailTextField.delegate = self
+        self.passwordTextField.delegate = self
     }
 
-    func createdSubviews() {
+    // MARK: - action methods
+    @objc private func dismissKeyboard() {
+        self.endEditing(true)
+    }
+
+    @objc private func keyboardWillShow(_ notification: NSNotification) {
+        guard let keyboardSize = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue else {
+                return
+            }
+
+        if passwordTextField.isFirstResponder {
+            self.frame.origin.y = -keyboardSize.height/2
+        }
+    }
+
+    @objc private func keyboardWillHide(_ notification: NSNotification) {
+        self.frame.origin.y = 0
+    }
+
+    // MARK: - private methods
+    private func setupKeyboardActions() {
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
+        self.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard)))
+    }
+
+    private func createdSubviews() {
         backgroundColor = .krelloBlue
 
         let loginStackView = makeStackView(36)
@@ -91,6 +121,9 @@ class LoginView: DefaultView {
         textField.backgroundColor = .white
         textField.font = UIFont.systemFont(ofSize: 18, weight: .regular)
         textField.setLeftPaddingPoints(8)
+        textField.returnKeyType = .done
+        textField.autocorrectionType = .no
+        textField.keyboardType = .emailAddress
         return textField
     }()
 
@@ -100,6 +133,10 @@ class LoginView: DefaultView {
         textField.placeholder = "password"
         textField.font = UIFont.systemFont(ofSize: 18, weight: .regular)
         textField.setLeftPaddingPoints(8)
+        textField.returnKeyType = .done
+        textField.keyboardType = .alphabet
+        textField.autocorrectionType = .no
+        textField.isSecureTextEntry = true
         return textField
     }()
 
@@ -130,5 +167,12 @@ class LoginView: DefaultView {
         stackView.translatesAutoresizingMaskIntoConstraints = false
         return stackView
     }
+}
 
+// MARK: - UITextFieldDelegate
+extension LoginView: UITextFieldDelegate {
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
+        return true
+    }
 }

--- a/Krello/Controller/LoginView.swift
+++ b/Krello/Controller/LoginView.swift
@@ -9,7 +9,7 @@ import UIKit
 
 class PaddedTextField: UITextField {
 
-    let padding = UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 8)
+    private let padding = UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 8)
 
     override open func textRect(forBounds bounds: CGRect) -> CGRect {
         return bounds.inset(by: padding)
@@ -76,7 +76,7 @@ class LoginView: DefaultView {
         ])
     }
 
-    let appNameLabel: UILabel = {
+    private let appNameLabel: UILabel = {
         let label = UILabel()
         label.text = "Krello"
         label.font = UIFont.systemFont(ofSize: 60, weight: .bold)
@@ -85,7 +85,7 @@ class LoginView: DefaultView {
         return label
     }()
 
-    let emailTextField: UITextField = {
+    private let emailTextField: UITextField = {
         let textField = PaddedTextField()
         textField.placeholder = "email"
         textField.backgroundColor = .white
@@ -94,7 +94,7 @@ class LoginView: DefaultView {
         return textField
     }()
 
-    let passwordTextField: UITextField = {
+    private let passwordTextField: UITextField = {
         let textField = PaddedTextField()
         textField.backgroundColor = .white
         textField.placeholder = "password"
@@ -103,7 +103,7 @@ class LoginView: DefaultView {
         return textField
     }()
 
-    let loginButton: UIButton = {
+    private let loginButton: UIButton = {
         let button = UIButton(type: .roundedRect)
         button.backgroundColor = .krelloGreen
         button.setTitle("로그인", for: .normal)
@@ -113,7 +113,7 @@ class LoginView: DefaultView {
         return button
     }()
 
-    let signupButton: UIButton = {
+    private let signupButton: UIButton = {
         let button = UIButton(type: .roundedRect)
         button.backgroundColor = .krelloGray
         button.setTitle("회원 가입", for: .normal)
@@ -123,7 +123,7 @@ class LoginView: DefaultView {
         return button
     }()
 
-    func makeStackView(_ spacing: CGFloat) -> UIStackView {
+    private func makeStackView(_ spacing: CGFloat) -> UIStackView {
         let stackView = UIStackView()
         stackView.axis = .vertical
         stackView.spacing = spacing

--- a/Krello/Controller/LoginView.swift
+++ b/Krello/Controller/LoginView.swift
@@ -154,7 +154,7 @@ class LoginView: DefaultView {
         return textField
     }()
 
-    private let loginButton: UIButton = {
+    let loginButton: UIButton = {
         let button = UIButton(type: .roundedRect)
         button.backgroundColor = .krelloGreen
         button.setTitle("로그인", for: .normal)
@@ -164,7 +164,7 @@ class LoginView: DefaultView {
         return button
     }()
 
-    private let signupButton: UIButton = {
+    let signupButton: UIButton = {
         let button = UIButton(type: .roundedRect)
         button.backgroundColor = .krelloGray
         button.setTitle("회원 가입", for: .normal)

--- a/Krello/Controller/LoginView.swift
+++ b/Krello/Controller/LoginView.swift
@@ -129,7 +129,7 @@ class LoginView: DefaultView {
         return label
     }()
 
-    private let emailTextField: UITextField = {
+    let emailTextField: UITextField = {
         let textField = PaddedTextField()
         textField.placeholder = "email"
         textField.backgroundColor = .white
@@ -141,7 +141,7 @@ class LoginView: DefaultView {
         return textField
     }()
 
-    private let passwordTextField: UITextField = {
+    let passwordTextField: UITextField = {
         let textField = PaddedTextField()
         textField.backgroundColor = .white
         textField.placeholder = "password"

--- a/Krello/Controller/LoginView.swift
+++ b/Krello/Controller/LoginView.swift
@@ -39,6 +39,9 @@ extension UITextField {
 }
 
 class LoginView: DefaultView {
+    var didTapSignupButton: (() -> Void)?
+    var didTapLoginButton: (() -> Void)?
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         createdSubviews()
@@ -46,9 +49,20 @@ class LoginView: DefaultView {
 
         self.emailTextField.delegate = self
         self.passwordTextField.delegate = self
+
+        self.signupButton.addTarget(self, action: #selector(touchUpSignupButton), for: .touchUpInside)
+        self.loginButton.addTarget(self, action: #selector(touchUpLoginButton), for: .touchUpInside)
     }
 
     // MARK: - action methods
+    @objc private func touchUpSignupButton() {
+        didTapSignupButton?()
+    }
+
+    @objc private func touchUpLoginButton() {
+        didTapLoginButton?()
+    }
+
     @objc private func dismissKeyboard() {
         self.endEditing(true)
     }

--- a/Krello/Controller/LoginViewController.swift
+++ b/Krello/Controller/LoginViewController.swift
@@ -13,6 +13,14 @@ class LoginViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         view = loginView
+
+        loginView.didTapLoginButton = {
+            print("로그인버튼 눌러버렸다")
+        }
+
+        loginView.didTapSignupButton = {
+            print("가입버튼 눌러버렸다")
+        }
     }
 }
 

--- a/KrelloTests/LoginViewTest.swift
+++ b/KrelloTests/LoginViewTest.swift
@@ -1,0 +1,57 @@
+//
+//  LoginViewTest.swift
+//  KrelloTests
+//
+//  Created by Sujin Jin on 2022/05/06.
+//
+
+import XCTest
+@testable import Krello
+
+class LoginViewTest: XCTestCase {
+
+    var sut: LoginView!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        sut = LoginView()
+    }
+
+    override func tearDownWithError() throws {
+        sut = nil
+        try super.tearDownWithError()
+    }
+
+    func test_loginButtonAction_touchUpInside() throws {
+        // Given:
+        let tapExpectation = expectation(description: #function)
+        sut.didTapLoginButton = {
+            tapExpectation.fulfill()
+        }
+
+        // When:
+        tap(sut.loginButton)
+
+        // Then:
+        wait(for: [tapExpectation], timeout: 0.1)
+    }
+
+    func test_signButtonAction_touchUpInside() throws {
+        // Given:
+        let tapExpectation = expectation(description: #function)
+        sut.didTapSignupButton = {
+            tapExpectation.fulfill()
+        }
+
+        // When:
+        tap(sut.signupButton)
+
+        // Then:
+        wait(for: [tapExpectation], timeout: 0.1)
+    }
+
+    // MARK: - helper methods
+    func tap(_ button: UIButton) {
+        button.sendActions(for: .touchUpInside)
+    }
+}

--- a/KrelloTests/LoginViewTest.swift
+++ b/KrelloTests/LoginViewTest.swift
@@ -18,6 +18,7 @@ class LoginViewTest: XCTestCase {
     }
 
     override func tearDownWithError() throws {
+        executeRunLoop()
         sut = nil
         try super.tearDownWithError()
     }
@@ -50,8 +51,28 @@ class LoginViewTest: XCTestCase {
         wait(for: [tapExpectation], timeout: 0.1)
     }
 
+    func test_emailTextField_whenShouldReturn_shouldMoveInputFocusToPasswordTextField() {
+        putInViewHierarchy(sut)
+
+        shouldReturn(in: sut.emailTextField)
+
+        XCTAssertTrue(sut.passwordTextField.isFirstResponder)
+    }
     // MARK: - helper methods
     func tap(_ button: UIButton) {
         button.sendActions(for: .touchUpInside)
+    }
+
+    func executeRunLoop() {
+        RunLoop.current.run(until: Date())
+    }
+
+    func putInViewHierarchy(_ view: UIView) {
+        let window = UIWindow()
+        window.addSubview(view)
+    }
+
+    @discardableResult func shouldReturn(in textField: UITextField) -> Bool? {
+        textField.delegate?.textFieldShouldReturn?(textField)
     }
 }

--- a/KrelloTests/LoginViewTest.swift
+++ b/KrelloTests/LoginViewTest.swift
@@ -58,6 +58,20 @@ class LoginViewTest: XCTestCase {
 
         XCTAssertTrue(sut.passwordTextField.isFirstResponder)
     }
+
+    func test_passwordTextField_whenShouldReturn_shouldDismissKeyboard() {
+        // Given
+        putInViewHierarchy(sut)
+        sut.passwordTextField.becomeFirstResponder()
+        XCTAssertTrue(sut.passwordTextField.isFirstResponder)
+
+        // When
+        shouldReturn(in: sut.passwordTextField)
+
+        // Then
+        XCTAssertFalse(sut.passwordTextField.isFirstResponder)
+    }
+
     // MARK: - helper methods
     func tap(_ button: UIButton) {
         button.sendActions(for: .touchUpInside)


### PR DESCRIPTION
## 📙 작업 내역
- [x] 배경화면을 터치하면 키보드를 내린다
- [x] 키보드의 done 버튼을 누르면 키보드를 내린다
- [x] 키보드가 올라왔을때, password textfield 라면 입력이 키보드에 가려지지 않도록 전체 화면을 올린다
- [x] 멤버변수, 메서드를 private 으로 변경
- [x] textfield 의 keyboard 타입 변경
- [x] button unit test

## 🤔 고민과 해결
- 키보드에 가려지는 입력뷰를 어느정도로 올려야 모든 디바이스에 호환이 될까...하는 고민
- `self.frame.origin.y = -keyboardSize.height/2`
- 현재는 키보드 높이의 절반만큼 뷰를 올리게 되어있다
- 입력 뷰(textfield) 의 위치가 키보드 높이보다 낮다면, 현재 키보드 높이보다 위에 위치하도록 화면을 움직이는 방법도 있을듯 하다
