### PR TITLE
[Rosa] login view 터치했을때 키보드가 내려갔는지 테스트

### DIFF
--- a/KrelloTests/LoginViewTest.swift
+++ b/KrelloTests/LoginViewTest.swift
@@ -72,6 +72,26 @@ class LoginViewTest: XCTestCase {
         XCTAssertFalse(sut.passwordTextField.isFirstResponder)
     }
 
+    func test_view_withEmailTextFieldFocus_whenTapGesture_shouldDismissKeyboard() {
+        // Given
+        putInViewHierarchy(sut)
+        sut.emailTextField.becomeFirstResponder()
+        XCTAssertTrue(sut.emailTextField.isFirstResponder)
+
+        // When
+        let gesture = sut.gestureRecognizers?.first { $0 is UITapGestureRecognizer }
+        let target = (gesture?.value(forKey: "_targets") as? [NSObject])?.first
+        let selectorString = String(describing: target)
+            .components(separatedBy: ", ")
+            .first?
+            .replacingOccurrences(of: "(action=", with: "")
+            .replacingOccurrences(of: "Optional(", with: "") ?? ""
+        sut.perform(.init(stringLiteral: selectorString))
+
+        // Then
+        XCTAssertFalse(sut.isFirstResponder)
+    }
+
     // MARK: - helper methods
     func tap(_ button: UIButton) {
         button.sendActions(for: .touchUpInside)


### PR DESCRIPTION
## 📙 작업 내역
- [x] Login View 를 터치했을떄(=tap gesture) 키보드가 내려갔는지 테스트 케이스 작성

## 🤔 고민과 해결
- view 를 터치했을때 이벤트를 어떻게 발생시키는가
- [뷰 테스트에 참고한 자료](https://medium.com/macoclock/testing-gestures-and-actions-8235188434f3)
- view 에 등록한 제스쳐를 가져와서 이벤트를 발생 시키는 듯 하다
- Objective-C 에서 사용되는 NSObjectProtocol>`perform()` 메서드가 이 역할을 하는 것이 아닌가 예상(공부더 필요)

## 💭 기타 설명
- NSObjectProtocol > perform(_:)
  - [apple document](https://developer.apple.com/documentation/objectivec/nsobjectprotocol/1418867-perform)
  - 예) `sut.perform(.init(stringLiteral: selectorString))`
  - Sends a specified message to the receiver and returns the result of the message.
  - 이 메서드를 호출하는 것은 receiver 에게 직접 aSelector message 를 보내는것과 같은 동작을 수행한다.

- `init(stringLiteral:)` string 으로 인스턴스를 생성
  - [document link](https://developer.apple.com/documentation/swift/string/1541044-init)