### PR TITLE
TableView DataSource 재사용가능하게 분리하기 

### DIFF
--- a/Krello.xcodeproj/project.pbxproj
+++ b/Krello.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		6FAA540228324F260060362A /* SignupFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FAA53FF28324F260060362A /* SignupFormView.swift */; };
 		9CFD1B2C1F608EA9228C54AB /* Pods_KrelloTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 992A62047D85C6E5349BC267 /* Pods_KrelloTests.framework */; };
 		B72508322834070300AD7595 /* TaskViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B72508312834070300AD7595 /* TaskViewController.swift */; };
+		B725085A2836670700AD7595 /* TableViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = B72508592836670700AD7595 /* TableViewDataSource.swift */; };
 		B73E718328328AC6007B4654 /* AuthenticationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B76D570E2826E1F4009EEAEC /* AuthenticationTest.swift */; };
 		B73E718428328AC6007B4654 /* AuthenticationManagerIntegrationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B76D570C2824F88C009EEAEC /* AuthenticationManagerIntegrationTest.swift */; };
 		B73E718528328AC6007B4654 /* ValidatorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B76D57032823F694009EEAEC /* ValidatorTest.swift */; };
@@ -81,6 +82,7 @@
 		A3D344D63B79E92BEEC611E7 /* Pods-KrelloTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KrelloTests.release.xcconfig"; path = "Target Support Files/Pods-KrelloTests/Pods-KrelloTests.release.xcconfig"; sourceTree = "<group>"; };
 		AAB53DB7ADEBD0FCFCF20435 /* Pods-Krello.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Krello.debug.xcconfig"; path = "Target Support Files/Pods-Krello/Pods-Krello.debug.xcconfig"; sourceTree = "<group>"; };
 		B72508312834070300AD7595 /* TaskViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskViewController.swift; sourceTree = "<group>"; };
+		B72508592836670700AD7595 /* TableViewDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableViewDataSource.swift; sourceTree = "<group>"; };
 		B74502312823944000172502 /* Validator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Validator.swift; path = Krello/Signup/Model/Validator.swift; sourceTree = SOURCE_ROOT; };
 		B74C02182828D90400C3602D /* AuthenticationEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationEngine.swift; sourceTree = "<group>"; };
 		B74C0222282A294700C3602D /* BoardLayoutMaker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BoardLayoutMaker.swift; sourceTree = "<group>"; };
@@ -289,6 +291,7 @@
 				BCD8350C2823C5C6001273C8 /* UIVIew+Extension.swift */,
 				BC22098C2823ADB200159AC0 /* UIStackView+Extension.swift */,
 				BCD8352D282B9540001273C8 /* PaddedLabel.swift */,
+				B72508592836670700AD7595 /* TableViewDataSource.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -649,6 +652,7 @@
 				B76D570B2824EE21009EEAEC /* AuthenticationInfo.swift in Sources */,
 				BCD83531282B9F9B001273C8 /* TaskTableViewCell.swift in Sources */,
 				6FAA53FC28324F0F0060362A /* SignupViewController.swift in Sources */,
+				B725085A2836670700AD7595 /* TableViewDataSource.swift in Sources */,
 				BCD83527282A0C7E001273C8 /* BoardListViewController.swift in Sources */,
 				BCD835112824FC98001273C8 /* main.swift in Sources */,
 				6F991C002832435900F4F772 /* FirestoreService.swift in Sources */,

--- a/Krello/BoardCRUD/Controller/BoardViewController.swift
+++ b/Krello/BoardCRUD/Controller/BoardViewController.swift
@@ -57,11 +57,6 @@ extension BoardViewController: UICollectionViewDataSource {
         dummyStatus.count
     }
 
-    func collectionView(_ collectionView: UICollectionView, didEndDisplaying cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
-        let cell = cell as? BoardCollectionViewCell
-        cell?.contentView.subviews.last?.removeFromSuperview()
-    }
-
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: BoardCollectionViewCell.identifier, for: indexPath) as? BoardCollectionViewCell else {return UICollectionViewCell()}
 

--- a/Krello/BoardCRUD/Controller/BoardViewController.swift
+++ b/Krello/BoardCRUD/Controller/BoardViewController.swift
@@ -16,6 +16,7 @@ class BoardViewController: UIViewController {
         super.viewDidLoad()
         configureSubviews()
         configureDisplay()
+
     }
 
     func configureDisplay() {
@@ -33,6 +34,14 @@ class BoardViewController: UIViewController {
         boardView.setDataSource(self)
         self.boardView = boardView
         self.view = boardView
+        configureChildViewController()
+    }
+
+    private func configureChildViewController () {
+        dummyStatus.forEach({
+            let taskVC = TaskViewController(status: $0)
+            self.addChild(taskVC)
+        })
     }
 
     override func viewWillLayoutSubviews() {
@@ -56,11 +65,10 @@ extension BoardViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: BoardCollectionViewCell.identifier, for: indexPath) as? BoardCollectionViewCell else {return UICollectionViewCell()}
 
-        let taskVC = TaskViewController(status: dummyStatus[indexPath.item])
-        cell.contentView.addSubview(taskVC.view)
-        cell.setConstraints(to: taskVC.view)
-        self.addChild(taskVC)
-        taskVC.didMove(toParent: self)
+        let childVC = self.children[indexPath.item]
+        cell.contentView.addSubview(childVC.view)
+        cell.setConstraints(to: childVC.view)
+        childVC.didMove(toParent: self)
         return cell
     }
 

--- a/Krello/BoardCRUD/View/BoardCollectionViewCell.swift
+++ b/Krello/BoardCRUD/View/BoardCollectionViewCell.swift
@@ -16,6 +16,11 @@ class BoardCollectionViewCell: UICollectionViewCell {
         configureDisplay()
     }
 
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        self.contentView.subviews.last?.removeFromSuperview()
+    }
+
     override func layoutSubviews() {
         super.layoutSubviews()
         configureShadow()

--- a/Krello/BoardCRUD/View/BoardCollectionViewCell.swift
+++ b/Krello/BoardCRUD/View/BoardCollectionViewCell.swift
@@ -11,11 +11,6 @@ class BoardCollectionViewCell: UICollectionViewCell {
 
     static let identifier = "BoardCollectionViewCell"
 
-    override func prepareForReuse() {
-        super.prepareForReuse()
-        self.contentView.subviews.last?.removeFromSuperview()
-    }
-
     override init(frame: CGRect) {
         super.init(frame: frame)
         configureDisplay()

--- a/Krello/Common/TableViewDataSource.swift
+++ b/Krello/Common/TableViewDataSource.swift
@@ -1,0 +1,42 @@
+//
+//  TableViewDataSource.swift
+//  Krello
+//
+//  Created by Kai Kim on 2022/05/19.
+//
+
+import UIKit
+struct TableConfigurator<Model> {
+     let cellConfigurator: (Model, UITableViewCell) -> Void
+     let numberOfRowsInSection: ([Model]) -> Int
+     let numberOfSections: ([Model]) -> Int
+}
+
+class TableViewDataSource<Model>: NSObject, UITableViewDataSource {
+
+    var tableConfigurator: TableConfigurator<Model>
+    var models: [Model]
+
+    private let reuseIdentifier: String
+
+    init(models: [Model], reuseIdentifier: String, tableConfigurator: TableConfigurator<Model>) {
+        self.models = models
+        self.reuseIdentifier = reuseIdentifier
+        self.tableConfigurator = tableConfigurator
+    }
+
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return tableConfigurator.numberOfSections(models)
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return tableConfigurator.numberOfRowsInSection(models)
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: reuseIdentifier, for: indexPath)
+        tableConfigurator.cellConfigurator(models[indexPath.item], cell)
+        return cell
+    }
+
+}

--- a/Krello/TaskCRUD/Controller/TaskViewController.swift
+++ b/Krello/TaskCRUD/Controller/TaskViewController.swift
@@ -47,13 +47,7 @@ class TaskViewController: UIViewController {
 
     private func configureContraints() {
         self.view.translatesAutoresizingMaskIntoConstraints = false
-        taskStackView.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            taskStackView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
-            taskStackView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 8),
-            taskStackView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            taskStackView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -8)
-        ])
+        taskStackView.setConstraints(to: self.view)
     }
 
     private func configureSubviews() {

--- a/Krello/TaskCRUD/Controller/TaskViewController.swift
+++ b/Krello/TaskCRUD/Controller/TaskViewController.swift
@@ -14,7 +14,7 @@ protocol TaskFetching {
 class TaskServiceMock: TaskFetching {
     func fetch(status: Task.Status) -> [Task] {
         return [Task(id: "ASDS234t6xc", title: "테스트1", status: .todo, contents: "오늘은", rowPosition: 0, createdAt: Date()),
-         Task(id: "ASDS234t6xc", title: "테스트2", status: .inprogress, contents: "오늘은 ", rowPosition: 1, createdAt: Date()),
+         Task(id: "ASDS234t6xc", title: "테스트2", status: .todo, contents: "오늘은 ", rowPosition: 1, createdAt: Date()),
                 Task(id: "ASDS234t6xc", title: "테스트3", status: .done, contents: "오늘은 ", rowPosition: 2, createdAt: Date())].filter({$0.status == status})
     }
 
@@ -22,10 +22,13 @@ class TaskServiceMock: TaskFetching {
 
 class TaskViewController: UIViewController {
 
-    lazy var taskStackView = TaskStackView(frame: self.view.bounds,
-                                           delegate: self, dataSource: self,
-                                           dragDelegate: self, dropDelegate: self)
-    private var tasks: [Task]?
+    lazy var taskStackView = TaskStackView(frame: self.view.bounds)
+    private var tableViewdataSource: UITableViewDataSource?
+    private var tableViewDelegate: UITableViewDelegate?
+    private var tableViewDragDelegate: UITableViewDragDelegate?
+    private var tableViewDropDelegate: UITableViewDropDelegate?
+
+    private var tasks = [Task]()
     private var status: Task.Status
     private let taskService: TaskFetching = TaskServiceMock()
 
@@ -55,46 +58,41 @@ class TaskViewController: UIViewController {
     }
 
     private func configureDisplay() {
+        setDataSource()
         updateTable()
+        tableViewDelegate =  self
+        tableViewDragDelegate = self
+        tableViewDropDelegate = self
+        self.taskStackView.taskTableView.delegate = tableViewDelegate
+        self.taskStackView.taskTableView.dragDelegate = tableViewDragDelegate
+        self.taskStackView.taskTableView.dropDelegate = tableViewDropDelegate
+    }
+
+    private func setDataSource() {
+        self.tasks = taskService.fetch(status: self.status)
+        let tableConfigurator = TableConfigurator <Task> { task, cell in
+            cell.textLabel?.text = task.title
+        } numberOfRowsInSection: { _ in
+            1
+        } numberOfSections: { models in
+            models.count
+        }
+        self.tableViewdataSource = TableViewDataSource(models: self.tasks,
+                                                       reuseIdentifier: TaskTableViewCell.identifier,
+                                                       tableConfigurator: tableConfigurator)
+        self.taskStackView.taskTableView.dataSource = tableViewdataSource
     }
 
     private func updateTable() {
-        tasks = taskService.fetch(status: self.status)
+        self.taskStackView.tableViewDelegate = self
         DispatchQueue.main.async {
             self.taskStackView.headerLabel.text = self.status.rawValue
             self.taskStackView.taskTableView.reloadData()
         }
     }
-
 }
 
-extension TaskViewController: UITableViewDataSource, UITableViewDelegate {
-
-    func numberOfSections(in tableView: UITableView) -> Int {
-        guard let tasks = tasks else {return 0}
-        return tasks.count
-    }
-
-    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return 1
-    }
-
-    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        5
-    }
-
-    func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        5
-    }
-
-    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let tasks = tasks else {return UITableViewCell()}
-        let cell = tableView.dequeueReusableCell(withIdentifier: TaskTableViewCell.identifier, for: indexPath)
-
-        cell.textLabel?.text = tasks[indexPath.section].title
-
-        return cell
-    }
+extension TaskViewController: UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         let view = UIView()
@@ -109,16 +107,12 @@ extension TaskViewController: UITableViewDataSource, UITableViewDelegate {
         view.heightAnchor.constraint(equalToConstant: 5).isActive = true
         return view
     }
-
 }
 
-extension TaskViewController: UITableViewDragDelegate, UITableViewDropDelegate {
+ extension TaskViewController: UITableViewDragDelegate, UITableViewDropDelegate {
     func tableView(_ tableView: UITableView, itemsForBeginning session: UIDragSession, at indexPath: IndexPath) -> [UIDragItem] {
 
-        guard let taskData = tasks?[indexPath.section] else {
-            return []
-        }
-
+        let taskData = tasks[indexPath.section]
         let itemProvider = NSItemProvider(object: taskData)
         let dragItem = UIDragItem(itemProvider: itemProvider)
         session.localContext = (self, indexPath, tableView)
@@ -145,8 +139,8 @@ extension TaskViewController: UITableViewDragDelegate, UITableViewDropDelegate {
                 }
 
                 self?.taskStackView.taskTableView.beginUpdates()
-                self?.tasks?.remove(at: from.section)
-                self?.tasks?.insert(draggedTask, at: to.section)
+                self?.tasks.remove(at: from.section)
+                self?.tasks.insert(draggedTask, at: to.section)
                 self?.taskStackView.taskTableView.reloadSections(updatedIndexSets, with: .automatic)
                 self?.taskStackView.taskTableView.endUpdates()
 
@@ -154,15 +148,15 @@ extension TaskViewController: UITableViewDragDelegate, UITableViewDropDelegate {
                 self?.removeFromTableData(localContext: coordinator.session.localDragSession?.localContext)
 
                 self?.taskStackView.taskTableView.beginUpdates()
-                self?.tasks?.insert(draggedTask, at: to.section)
+                self?.tasks.insert(draggedTask, at: to.section)
                 self?.taskStackView.taskTableView.insertSections(IndexSet(integer: to.section), with: .automatic)
                 self?.taskStackView.taskTableView.endUpdates()
 
             case (nil, nil):
                 self?.removeFromTableData(localContext: coordinator.session.localDragSession?.localContext)
                 self?.taskStackView.taskTableView.beginUpdates()
-                self?.tasks?.append(draggedTask)
-                self?.taskStackView.taskTableView.insertSections(IndexSet(integer: (self?.tasks!.count)!-1), with: .automatic)
+                self?.tasks.append(draggedTask)
+                self?.taskStackView.taskTableView.insertSections(IndexSet(integer: (self?.tasks.count)!-1), with: .automatic)
                 self?.taskStackView.taskTableView.endUpdates()
 
             default: break
@@ -176,7 +170,7 @@ extension TaskViewController: UITableViewDragDelegate, UITableViewDropDelegate {
         guard let (dataSource, from, tableView) = localContext as? (TaskViewController, IndexPath, UITableView) else { return }
 
         tableView.beginUpdates()
-        dataSource.tasks?.remove(at: from.section)
+        dataSource.tasks.remove(at: from.section)
         tableView.deleteSections(IndexSet(integer: from.section), with: .automatic)
         tableView.endUpdates()
     }
@@ -184,4 +178,4 @@ extension TaskViewController: UITableViewDragDelegate, UITableViewDropDelegate {
     func tableView(_ tableView: UITableView, dropSessionDidUpdate session: UIDropSession, withDestinationIndexPath destinationIndexPath: IndexPath?) -> UITableViewDropProposal {
         UITableViewDropProposal(operation: .move, intent: .insertAtDestinationIndexPath)
     }
-}
+ }

--- a/Krello/TaskCRUD/View/TaskStackView.swift
+++ b/Krello/TaskCRUD/View/TaskStackView.swift
@@ -25,16 +25,9 @@ class TaskStackView: UIStackView {
     lazy var taskTableView: UITableView = { [weak self] in
         let tableview = UITableView(frame: .zero, style: .grouped)
         tableview.register(TaskTableViewCell.self, forCellReuseIdentifier: TaskTableViewCell.identifier)
-
         tableview.backgroundColor = .krelloGray
-        tableview.delegate = tableViewDelegate
-        tableview.dataSource = tableViewDataSource
-
         tableview.dragInteractionEnabled = true
-        tableview.dropDelegate = tableViewDropDelegate
-        tableview.dragDelegate = tableViewDragDelegate
         tableview.translatesAutoresizingMaskIntoConstraints = false
-
         return tableview
     }()
 
@@ -61,16 +54,8 @@ class TaskStackView: UIStackView {
     var tableViewDragDelegate: UITableViewDragDelegate?
     var tableViewDropDelegate: UITableViewDropDelegate?
 
-    init(frame: CGRect,
-         delegate: UITableViewDelegate,
-         dataSource: UITableViewDataSource,
-         dragDelegate: UITableViewDragDelegate,
-         dropDelegate: UITableViewDropDelegate) {
+    override init(frame: CGRect) {
         super.init(frame: frame)
-        self.tableViewDelegate = delegate
-        self.tableViewDataSource = dataSource
-        self.tableViewDragDelegate = dragDelegate
-        self.tableViewDropDelegate = dropDelegate
 
         axis = .vertical
         distribution = .fill

--- a/Krello/TaskCRUD/View/TaskStackView.swift
+++ b/Krello/TaskCRUD/View/TaskStackView.swift
@@ -84,6 +84,16 @@ class TaskStackView: UIStackView {
         ])
     }
 
+    func setConstraints(to view: UIView) {
+        self.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            self.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            self.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 8),
+            self.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            self.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -8)
+        ])
+
+    }
     required init(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }


### PR DESCRIPTION

## 📙 작업 내역
- #59 

## 🤔 고민과 해결
 BoardListVC 와 TaskViewVC 의 TableViewDataSource 를 합치는데 `numberOfSections` , `numberOfRowsInSection` 의 구현이 달라서 `TableConfigurator` 라는 스트럭쳐를 제네릭한 `TableViewDataSource` 에 프로퍼티 설정 해주었습니다.

